### PR TITLE
3.1.1.10

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
         continue-on-error: true
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+                python-version: ['3.6', '3.7', '3.8', '3.9']
         env:
             FLAKE8_VERSION: "==3.8.4"
             FLAKE8_CONFIG: ".flake8"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
         continue-on-error: true
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9']
+                python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         env:
             FLAKE8_VERSION: "==3.8.4"
             FLAKE8_CONFIG: ".flake8"

--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -348,8 +348,8 @@ def get_logging_info(realtimelogging, catchall, realtime_logname, realtime_loggi
     info_dic = {}
 
     if 'logging=' not in catchall or not realtimelogging:
-        logger.debug(f'catchall={catchall}')
-        logger.debug(f'realtimelogging={realtimelogging}')
+        #logger.debug(f'catchall={catchall}')
+        #logger.debug(f'realtimelogging={realtimelogging}')
         return {}
 
     # args handling
@@ -424,7 +424,7 @@ def run_realtimelog(queues, traces, args):
             job.realtimelogging = True
 
         # testing
-        job.realtimelogging = True
+        # job.realtimelogging = True
         # reset info_dic if real-time logging is not wanted by the job
         if not job.realtimelogging:
             info_dic = None
@@ -433,7 +433,7 @@ def run_realtimelog(queues, traces, args):
                                     job.infosys.queuedata.catchall,
                                     args.realtime_logname,
                                     args.realtime_logging_server) if not info_dic and job.realtimelogging else info_dic
-        logger.debug(f'info_dic={info_dic}')
+        # logger.debug(f'info_dic={info_dic}')
         if info_dic:
             args.use_realtime_logging = True
             realtime_logger = get_realtime_logger(args, info_dic)


### PR DESCRIPTION
* Skipping sourcing of atlasLocalSetup (as well as executing lsetup emi) when setting up arcproxy
  * Command should already be available in the environment since wrapper sets it up
  * Pilot wrapper has also been updated since atlasLocalSetup was set up twice (now only sourced in local setup)
* Added iterative function to determine a good fitting range for payload memory usage fittings
  * Suggested by M. Maeno
* Removed workDir from list of items to check in looping test
  * Requested by R. Walker
* Bug fixes
  * Improved identification of zero size output files (could previously have been reported as file size too large!)
  * Fixed rare exceptions with reading /proc/%d/stat. Affected a handful of jobs
    * E.g. https://bigpanda.cern.ch/job?pandaid=5329275519