### PR TITLE
fixed url and use-https=False issues

### DIFF
--- a/pilot.py
+++ b/pilot.py
@@ -30,7 +30,7 @@ from pilot.util.constants import SUCCESS, FAILURE, ERRNO_NOJOBS, PILOT_START_TIM
     SERVER_UPDATE_NOT_DONE, PILOT_MULTIJOB_START_TIME
 from pilot.util.filehandling import get_pilot_work_dir, mkdirs, establish_logging
 from pilot.util.harvester import is_harvester_mode
-from pilot.util.https import https_setup, send_update
+from pilot.util.https import get_panda_server, https_setup, send_update
 from pilot.util.timing import add_to_pilot_timing
 
 errors = ErrorCodes()
@@ -452,9 +452,7 @@ def set_environment_variables():
         environ['PILOT_OUTPUT_DIR'] = args.output_dir
 
     # keep track of the server urls
-    _port = ":%s" % args.port
-    url = args.url if _port in args.url else args.url + _port
-    environ['PANDA_SERVER_URL'] = url
+    environ['PANDA_SERVER_URL'] = get_panda_server(args.url, args.port)
     environ['QUEUEDATA_SERVER_URL'] = '%s' % args.queuedata_url
 
 
@@ -582,11 +580,11 @@ if __name__ == '__main__':
     if exit_code != 0:
         sys.exit(exit_code)
 
-    # set environment variables (to be replaced with singleton implementation)
-    set_environment_variables()
-
     # setup and establish standard logging
     establish_logging(debug=args.debug, nopilotlog=args.nopilotlog)
+
+    # set environment variables (to be replaced with singleton implementation)
+    set_environment_variables()
 
     # execute main function
     trace = main()

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -416,7 +416,7 @@ def get_panda_server(url, port):
         parsedloc = loc.split(':')
         loc = parsedloc[0]
 
-        # use port in url only if port argument is not provided
+        # if a port is provided in the url, then override the port argument
         if len(parsedloc) == 2:
             port = parsedloc[1]
         # default scheme to https


### PR DESCRIPTION
* Fixed an issue with the pandaserver url parsing in job.py.
    * Whenever you specify both the http protocol in --url and a port as cli arguments ( `./pilot.py --url http://pandaserverurl -p 25080 ...`) then the port gets ignored and updateJob requests are sent to `http://pandaserverurl`. The reason was that the prefix `http://` is not removed and the conditional at [Line 458](https://github.com/PanDAWMS/pilot2/blob/029e013dec888eecadb34c485f8d7498fccd000f/pilot/control/job.py#L458) finds `:`and ignore the port.
  * Note that this was only affecting updateJob requests, getJob, UpdateEventRanges and other requests were using the correct URL.
* When using `--use-https=False` there is an exception occurring in [get_curl_command](https://github.com/PanDAWMS/pilot2/blob/029e013dec888eecadb34c485f8d7498fccd000f/pilot/util/https.py#L248) as it is still called and is using the `_ctx`object however `https_setup()` was never called to initialize the module.