### PR TITLE
Ignore RSE availability status for stageout transfers using Rucio copytool

### DIFF
--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -638,7 +638,7 @@ def _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out, tra
         logger.info('*** rucio API uploading file (taking over logging) ***')
         logger.debug('summary_file_path=%s' % summary_file_path)
         logger.debug('trace_report_out=%s' % trace_report_out)
-        result = upload_client.upload([f], summary_file_path=summary_file_path, traces_copy_out=trace_report_out)
+        result = upload_client.upload([f], summary_file_path=summary_file_path, traces_copy_out=trace_report_out, ignore_availability=True)
     except Exception as error:
         logger.warning('*** rucio API upload client failed ***')
         logger.warning('caught exception: %s', error)


### PR DESCRIPTION
use `ignore_availability=True` for stage-out transfers by `rucio` copytool

ref: #40