### PR TITLE
Changed to have consistent fun signature among users

### DIFF
--- a/pilot/user/generic/common.py
+++ b/pilot/user/generic/common.py
@@ -109,7 +109,7 @@ def update_job_data(job):
     pass
 
 
-def remove_redundant_files(workdir, outputfiles=[], piloterrors=[], debugmode=False):
+def remove_redundant_files(workdir, outputfiles=None, piloterrors=[], debugmode=False):
     """
     Remove redundant files and directories prior to creating the log file.
 
@@ -143,7 +143,7 @@ def get_utility_commands(order=None, job=None):
     return {}
 
 
-def get_utility_command_setup(name, setup=None):
+def get_utility_command_setup(name, job, setup=None):
     """
     Return the proper setup for the given utility command.
     If a payload setup is specified

--- a/pilot/user/rubin/common.py
+++ b/pilot/user/rubin/common.py
@@ -110,7 +110,7 @@ def update_job_data(job):
     pass
 
 
-def remove_redundant_files(workdir, outputfiles=[], piloterrors=[], debugmode=False):
+def remove_redundant_files(workdir, outputfiles=None, piloterrors=[], debugmode=False):
     """
     Remove redundant files and directories prior to creating the log file.
 
@@ -145,7 +145,7 @@ def get_utility_commands(order=None, job=None):
     return {}
 
 
-def get_utility_command_setup(name, setup=None):
+def get_utility_command_setup(name, job, setup=None):
     """
     Return the proper setup for the given utility command.
     If a payload setup is specified

--- a/pilot/user/sphenix/common.py
+++ b/pilot/user/sphenix/common.py
@@ -109,7 +109,7 @@ def update_job_data(job):
     pass
 
 
-def remove_redundant_files(workdir, outputfiles=[], piloterrors=[], debugmode=False):
+def remove_redundant_files(workdir, outputfiles=None, piloterrors=[], debugmode=False):
     """
     Remove redundant files and directories prior to creating the log file.
 
@@ -143,7 +143,7 @@ def get_utility_commands(order=None, job=None):
     return {}
 
 
-def get_utility_command_setup(name, setup=None):
+def get_utility_command_setup(name, job, setup=None):
     """
     Return the proper setup for the given utility command.
     If a payload setup is specified


### PR DESCRIPTION
Changed to make the functions get_utility_command_setup and remove_redundant_files with consistent signature among all pilot/user/*/common.py