### PR TITLE
Nersc user resource and CA event service support

### DIFF
--- a/pilot/eventservice/esprocess/esprocess.py
+++ b/pilot/eventservice/esprocess/esprocess.py
@@ -126,11 +126,10 @@ class ESProcess(threading.Thread):
         if "PILOT_EVENTRANGECHANNEL" in executable:
             executable = "export PILOT_EVENTRANGECHANNEL=\"%s\"; " % (socket_name) + executable
         elif "--preExec" not in executable:
-            pre_exec_param = " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\'" % (socket_name)
             executable = executable().strip()
             if executable.endswith(";"):
                 executable = executable[:-1]
-            executable += pre_exec_param
+            executable += " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\'" % (socket_name)
         else:
             if "import jobproperties as jps" in executable:
                 executable = executable.replace("import jobproperties as jps;",

--- a/pilot/eventservice/esprocess/esprocess.py
+++ b/pilot/eventservice/esprocess/esprocess.py
@@ -126,9 +126,9 @@ class ESProcess(threading.Thread):
 
         is_ca = "--CA" in executable
         if is_ca:
-            preexec_socket_config = " --preExec \'ConfigFlags.MP.EventRangeChannel=\"%s\"\'" % (socket_name)
+            preexec_socket_config = " --preExec \'ConfigFlags.MP.EventRangeChannel=\"%s\"\' " % (socket_name)
         else:
-            preexec_socket_config = " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\'" % (socket_name)
+            preexec_socket_config = " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\' " % (socket_name)
 
         if "PILOT_EVENTRANGECHANNEL" in executable:
             executable = "export PILOT_EVENTRANGECHANNEL=\"%s\"; " % (socket_name) + executable

--- a/pilot/eventservice/esprocess/esprocess.py
+++ b/pilot/eventservice/esprocess/esprocess.py
@@ -128,7 +128,8 @@ class ESProcess(threading.Thread):
         if is_ca:
             preexec_socket_config = " --preExec \'ConfigFlags.MP.EventRangeChannel=\"%s\"\' " % (socket_name)
         else:
-            preexec_socket_config = " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\' " % (socket_name)
+            preexec_socket_config = \
+                " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\' " % (socket_name)
 
         if "PILOT_EVENTRANGECHANNEL" in executable:
             executable = "export PILOT_EVENTRANGECHANNEL=\"%s\"; " % (socket_name) + executable

--- a/pilot/eventservice/esprocess/esprocess.py
+++ b/pilot/eventservice/esprocess/esprocess.py
@@ -126,7 +126,11 @@ class ESProcess(threading.Thread):
         if "PILOT_EVENTRANGECHANNEL" in executable:
             executable = "export PILOT_EVENTRANGECHANNEL=\"%s\"; " % (socket_name) + executable
         elif "--preExec" not in executable:
-            executable += " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\'" % (socket_name)
+            pre_exec_param = " --preExec \'from AthenaMP.AthenaMPFlags import jobproperties as jps;jps.AthenaMPFlags.EventRangeChannel=\"%s\"\'" % (socket_name)
+            executable = executable().strip()
+            if executable.endswith(";"):
+                executable = executable[:-1]
+            executable += pre_exec_param
         else:
             if "import jobproperties as jps" in executable:
                 executable = executable.replace("import jobproperties as jps;",

--- a/pilot/user/atlas/resource/nersc.py
+++ b/pilot/user/atlas/resource/nersc.py
@@ -65,7 +65,11 @@ def get_setup_command(job, prepareasetup):
         if os.environ.get('HARVESTER_PYTHONPATH', '') != "":
             cmd += "export PYTHONPATH=$HARVESTER_PYTHONPATH:$PYTHONPATH;"
         #set FRONTIER_SERVER for NERSC
-        cmd += "export FRONTIER_SERVER=\"(serverurl=http://atlasfrontier-ai.cern.ch:8000/atlr)(serverurl=http://atlasfrontier2-ai.cern.ch:8000/atlr)(serverurl=http://atlasfrontier1-ai.cern.ch:8000/atlr)(proxyurl=http://frontiercache.nersc.gov:3128)\""
+        cmd += ("export FRONTIER_SERVER="
+                "\"(serverurl=http://atlasfrontier-ai.cern.ch:8000/atlr)"
+                "(serverurl=http://atlasfrontier2-ai.cern.ch:8000/atlr)"
+                "(serverurl=http://atlasfrontier1-ai.cern.ch:8000/atlr)"
+                "(proxyurl=http://frontiercache.nersc.gov:3128)\"")
 
         logger.debug('get_setup_command return value: {0}'.format(str(cmd)))
 

--- a/pilot/user/atlas/resource/nersc.py
+++ b/pilot/user/atlas/resource/nersc.py
@@ -64,8 +64,8 @@ def get_setup_command(job, prepareasetup):
         # test if HARVESTER_PYTHONPATH is defined
         if os.environ.get('HARVESTER_PYTHONPATH', '') != "":
             cmd += "export PYTHONPATH=$HARVESTER_PYTHONPATH:$PYTHONPATH;"
-        #unset FRONTIER_SERVER variable
-        cmd += "unset FRONTIER_SERVER"
+        #set FRONTIER_SERVER for NERSC
+        cmd += "export FRONTIER_SERVER=\"(serverurl=http://atlasfrontier-ai.cern.ch:8000/atlr)(serverurl=http://atlasfrontier2-ai.cern.ch:8000/atlr)(serverurl=http://atlasfrontier1-ai.cern.ch:8000/atlr)(proxyurl=http://frontiercache.nersc.gov:3128)\""
 
         logger.debug('get_setup_command return value: {0}'.format(str(cmd)))
 


### PR DESCRIPTION
* Rename resource from Cori to Nersc since Cori is reaching end of life and transitioning to Perlmutter
* Update `FRONTIER_SERVER` to use nersc proxy
* Fixed an issue when trying to append `--preExec` to the executable; it is terminated by ";" and the `preExec` argument in not added correctly to the command line.
* correctly configures event service job with CA