### PR TITLE
preserve pilot source timestamps while copying files into container

### DIFF
--- a/pilot/util/filehandling.py
+++ b/pilot/util/filehandling.py
@@ -1115,7 +1115,7 @@ def copy_pilot_source(workdir, filename=None):
     try:
         logger.debug(f'copy {srcdir} to {workdir}')
         pat = '%s' if filename else '%s/*'
-        cmd = f'cp -r {pat} %s' % (srcdir, workdir)
+        cmd = f'cp -pr {pat} %s' % (srcdir, workdir)
         exit_code, stdout, _ = execute(cmd)
         if exit_code != 0:
             diagnostics = f'file copy failed: {exit_code}, {stdout}'


### PR DESCRIPTION
Preserve file attributes (timestamps,mode,ownership) while copying pilot sources into container.

This fix is used to avoid getting example `queuedata.json` https://github.com/PanDAWMS/pilot3/blob/master/queuedata.json into the container as a cache (with refreshed time) and let `pilot.info` to refetch new `queuedata.json` which appropriate content for a job 