### PR TITLE
tracereport: also catch gaierror for gethostbyaddr()

### DIFF
--- a/pilot/util/tracereport.py
+++ b/pilot/util/tracereport.py
@@ -115,7 +115,7 @@ class TraceReport(dict):
 
         try:
             self['hostname'] = socket.gethostbyaddr(hostname)[0]
-        except socket.herror as exc:
+        except (socket.gaierror, socket.herror) as exc:
             logger.warning(f'unable to detect hostname by address for trace report: {exc}')
             self['hostname'] = 'unknown'
 


### PR DESCRIPTION
socket.gethostbyaddr() throws a socket.gaierror exception if the address can not be resolved which was not caught before.

Fixes regression introduced by e7d7c6f , after which Pilot yielded stage-in and stage-out errors with backtrace for sites using a non-DNS resolvable PANDA_HOSTNAME (VMs, long-lived containers,...).

Reopened against `next` branch. 