### PR TITLE
optimize loki

### DIFF
--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -444,7 +444,7 @@ def get_logging_info(job: JobData, args: object) -> dict:
             logger.info("correct logserver formal: logging_type;protocol://hostname:port")
             return {}
 
-        regex = r"logserver='(?P<logging_type>[^;]+);(?P<protocol>[^:]+)://(?P<hostname>[^:]+):(?P<port>\d+)'"
+        regex = r"logserver=(?P<logging_type>[^;]+);(?P<protocol>[^:]+)://(?P<hostname>[^:]+):(?P<port>\d+)"
         match = search(regex, logserver)
         if match:
             logging_type = match.group('logging_type')

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -858,7 +858,8 @@ def request2(url: str = "",
     # Send the request securely
     try:
         logger.debug('sending data to server')
-        with urllib.request.urlopen(req, context=ssl_context, timeout=30) as response:
+        timeout = int(config.Pilot.http_maxtime)
+        with urllib.request.urlopen(req, context=ssl_context, timeout=timeout) as response:
             # Handle the response here
             logger.debug(f"response.status={response.status}, response.reason={response.reason}")
             ret = response.read().decode('utf-8')

--- a/pilot/util/lokirealtimelogger.py
+++ b/pilot/util/lokirealtimelogger.py
@@ -51,18 +51,22 @@ class PilotLokiLoggerFormatter:
 
         formatted = {
             "timestamp": record.created,
-            "process": record.process,
-            "thread": record.thread,
+            # "process": record.process,
+            # "thread": record.thread,
             "function": record.funcName,
             "module": record.module,
             "name": record.name,
             "level": record.levelname,
         }
 
+        """
+        # Not send all information, some loki services have limitations on number of labels.
+
         record_keys = set(record.__dict__.keys())
         for key in record_keys:
             if key not in formatted and key not in ['msg']:
                 formatted[key] = getattr(record, key)
+        """
 
         message = record.msg
         try:


### PR DESCRIPTION
(1) set timeout to http_maxtime in https.request2, which can be compatible with https.request.
(2) update the logserver format to remove single quotes. Because with bash command arguments, the single quotes are not easy to be passed to the variables.
(3) update loki handler, to remove to items. In the new tests, it seems the loki server limits the number of labels. Here we publish too many labels which are not useful. So I removed these labels.